### PR TITLE
Implement header-based session verification logic

### DIFF
--- a/apps/app/src/components/custom-ui/tool-execution-modal.tsx
+++ b/apps/app/src/components/custom-ui/tool-execution-modal.tsx
@@ -520,6 +520,15 @@ export function ToolExecutionModal({ isOpen, onClose, tool, serverId, url }: Too
         }
 
 
+        // Control-plane hints for proxy behavior
+        const wantsExternalFlow = activeWallet?.walletType === 'external';
+        const controlHeaders: Record<string, string> = {};
+        if (wantsExternalFlow) {
+          controlHeaders['X-MCPAY-AUTH-MODE'] = 'none';
+          controlHeaders['X-MCPAY-AUTOPAY'] = 'off';
+          controlHeaders['X-MCPAY-402-MODE'] = 'x420';
+        }
+
         const transport = new StreamableHTTPClientTransport(mcpUrl, {
           requestInit: {
             credentials: 'include',
@@ -528,6 +537,7 @@ export function ToolExecutionModal({ isOpen, onClose, tool, serverId, url }: Too
               'X-Wallet-Type': activeWallet?.walletType || 'unknown',
               'X-Wallet-Address': walletAddress || '',
               'X-Wallet-Provider': activeWallet?.provider || 'unknown',
+              ...controlHeaders,
               // Explicitly include cookies if available
               ...(document.cookie ? { 'Cookie': document.cookie } : {}),
             }


### PR DESCRIPTION
Add header-based control to the MCP proxy server to allow clients to explicitly manage authentication, auto-payment, and x402 error handling.

This enables clients like the JS SDK CLI and browser-based wallets to specify how the `/mcp` proxy should handle session verification (API key, MCP auth, or none), whether to engage the x402 auto-payment hook, and if x402 errors should result in an HTTP 420 status code for easier client-side processing. This provides a flexible control plane for diverse client needs.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7d3fe3e-9558-4b8c-aff1-4c4345cbea7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d7d3fe3e-9558-4b8c-aff1-4c4345cbea7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

